### PR TITLE
bump riemann to 2.8 and fix riemann-tool dependency

### DIFF
--- a/scripts/riemann.sh
+++ b/scripts/riemann.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-VERSION=0.2.6
+VERSION=0.2.8
 
 apt-get -y install openjdk-7-jre ruby-dev
 cd /var/tmp
@@ -22,8 +22,8 @@ initctl reload-configuration riemann
 service riemann restart
 
 # Nokogiri
-apt-get -y install libxslt-dev libxml2-dev
-gem install nokogiri -v '1.5.9' --no-ri --no-rdoc
+apt-get -y install libxslt-dev libxml2-dev zlib1g-dev
+gem install nokogiri --no-ri --no-rdoc
 
 gem install riemann-tools --no-ri --no-rdoc
 riemann-health --host 127.0.0.1 --tag location=london --tag os=linux &


### PR DESCRIPTION
When I use `vagrant up alerta-riemann`, show this error

```
==> alerta-riemann: ERROR:  Error installing riemann-tools:
==> alerta-riemann:     ERROR: Failed to build gem native extension.
==> alerta-riemann:
==> alerta-riemann:         /usr/bin/ruby1.9.1 extconf.rb
==> alerta-riemann: checking if the C compiler accepts ... yes
==> alerta-riemann: Building nokogiri using packaged libraries.
==> alerta-riemann: checking for gzdopen() in -lz... no
==> alerta-riemann: zlib is missing; necessary for building libxml2
==> alerta-riemann: *** extconf.rb failed ***
==> alerta-riemann: Could not create Makefile due to some reason, probably lack of
==> alerta-riemann: necessary libraries and/or headers.  Check the mkmf.log file for more
==> alerta-riemann: details.  You may need configuration options.
==> alerta-riemann:
==> alerta-riemann: Provided configuration options:
==> alerta-riemann:     --with-opt-dir
==> alerta-riemann:     --without-opt-dir
==> alerta-riemann:     --with-opt-include
==> alerta-riemann:     --without-opt-include=${opt-dir}/include
==> alerta-riemann:     --with-opt-lib
==> alerta-riemann:     --without-opt-lib=${opt-dir}/lib
==> alerta-riemann:     --with-make-prog
==> alerta-riemann:     --without-make-prog
==> alerta-riemann:     --srcdir=.
==> alerta-riemann:     --curdir
==> alerta-riemann:     --ruby=/usr/bin/ruby1.9.1
==> alerta-riemann:     --help
==> alerta-riemann:     --clean
==> alerta-riemann:     --use-system-libraries
==> alerta-riemann:     --enable-static
==> alerta-riemann:     --disable-static
==> alerta-riemann:     --with-zlib-dir
==> alerta-riemann:     --without-zlib-dir
==> alerta-riemann:     --with-zlib-include
==> alerta-riemann:     --without-zlib-include=${zlib-dir}/include
==> alerta-riemann:     --with-zlib-lib
==> alerta-riemann:     --without-zlib-lib=${zlib-dir}/lib
==> alerta-riemann:     --enable-cross-build
==> alerta-riemann:     --disable-cross-build
==> alerta-riemann:
==> alerta-riemann:
==> alerta-riemann: Gem files will remain installed in /var/lib/gems/1.9.1/gems/nokogiri-1.6.6.2 for inspection.
==> alerta-riemann: Results logged to /var/lib/gems/1.9.1/gems/nokogiri-1.6.6.2/ext/nokogiri/gem_make.out
```

I checked Nokoiri installing document, find out we should install zlib1g-dev first.
http://www.nokogiri.org/tutorials/installing_nokogiri.html
