### PR TITLE
Update and fix CentOS vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,8 +26,10 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "alerta-centos", primary: true do |centos7|
-    centos7.vm.box = "centos71"
-    centos7.vm.box_url = "https://github.com/CommanderK5/packer-centos-template/releases/download/0.7.1/vagrant-centos-7.1.box"
+    #centos7.vm.box = "centos71"
+    #centos7.vm.box_url = "https://github.com/CommanderK5/packer-centos-template/releases/download/0.7.1/vagrant-centos-7.1.box"
+    centos7.vm.box = "centos/7"
+    centos7.vm.box_url = "https://atlas.hashicorp.com/centos/boxes/7/versions/1605.01/providers/virtualbox.box"
     centos7.vm.network :private_network, ip: "192.168.0.110"
     centos7.vm.provision :shell, :path => "scripts/centos/base.sh"
     centos7.vm.provision :shell, :path => "scripts/centos/alerta.sh"

--- a/scripts/centos/alerta.sh
+++ b/scripts/centos/alerta.sh
@@ -9,6 +9,8 @@ yum -y install httpd mod_wsgi mongodb-server
 pip install --upgrade pip setuptools wheel virtualenv
 
 grep -q ^smallfiles /etc/mongod.conf || echo "smallfiles = true" | tee -a /etc/mongod.conf
+systemctl start mongod
+systemctl enable mongod
 
 id alerta || (groupadd alerta && useradd -g alerta alerta)
 cd /opt

--- a/scripts/centos/alerta.sh
+++ b/scripts/centos/alerta.sh
@@ -6,9 +6,9 @@ export AUTH_REQUIRED=False
 
 yum -y install gcc python-pip python-devel python-setuptools python-virtualenv libffi-devel openssl-devel
 yum -y install httpd mod_wsgi mongodb-server
+pip install --upgrade pip setuptools wheel virtualenv
 
 grep -q ^smallfiles /etc/mongod.conf || echo "smallfiles = true" | tee -a /etc/mongod.conf
-service mongod restart
 
 id alerta || (groupadd alerta && useradd -g alerta alerta)
 cd /opt
@@ -55,7 +55,8 @@ PLUGINS = ['reject']
 EOF
 
 echo "ServerName localhost" >>/etc/httpd/conf/httpd.conf
-apachectl restart
+systemctl start httpd
+systemctl enable httpd
 
 cd /var/www && rm -Rf html/*
 wget -q -O - https://github.com/alerta/angular-alerta-webui/tarball/master | tar zxf -

--- a/scripts/centos/alerta.sh
+++ b/scripts/centos/alerta.sh
@@ -9,6 +9,7 @@ yum -y install httpd mod_wsgi mongodb-server
 pip install --upgrade pip setuptools wheel virtualenv
 
 grep -q ^smallfiles /etc/mongod.conf || echo "smallfiles = true" | tee -a /etc/mongod.conf
+/usr/sbin/setsebool -P httpd_can_network_connect 1  # change SELinux policy to allow httpd modules to connect to databases over the network
 systemctl start mongod
 systemctl enable mongod
 


### PR DESCRIPTION
This uses an updated CentOS 7 box and fixes the bug of not being able to communicate with MongoDB because of a SELinux boolean value.
