### PR TITLE
Convert alerta server install script to Python 3

### DIFF
--- a/scripts/alerta.sh
+++ b/scripts/alerta.sh
@@ -5,20 +5,20 @@ set -x
 export AUTH_REQUIRED=False
 
 apt-get -y update
-DEBIAN_FRONTEND=noninteractive apt-get -y install git wget build-essential python python-setuptools python-pip python-dev python-virtualenv libffi-dev
-DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 libapache2-mod-wsgi
+DEBIAN_FRONTEND=noninteractive apt-get -y install git wget build-essential python3 python3-setuptools python3-pip python3-dev python3-venv libffi-dev
+DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 libapache2-mod-wsgi-py3
 
 id alerta || (groupadd alerta && useradd -g alerta alerta)
 cd /opt
-virtualenv alerta
-alerta/bin/pip install alerta-server alerta
+python3 -m venv alerta
+alerta/bin/pip install --upgrade pip wheel alerta-server alerta
 echo "PATH=$PATH:/opt/alerta/bin" >/etc/profile.d/alerta.sh
 
 cat >/etc/apache2/sites-available/000-default.conf << EOF
 Listen 8080
 <VirtualHost *:8080>
   ServerName localhost
-  WSGIDaemonProcess alerta processes=5 threads=5
+  WSGIDaemonProcess alerta processes=5 threads=5 python-home=/opt/alerta
   WSGIProcessGroup alerta
   WSGIApplicationGroup %{GLOBAL}
   WSGIScriptAlias / /var/www/api.wsgi
@@ -38,13 +38,11 @@ Listen 8080
 EOF
 
 cat >/var/www/api.wsgi << EOF
-#!/usr/bin/env python
-activate_this = '/opt/alerta/bin/activate_this.py'
-execfile(activate_this, dict(__file__=activate_this))
 from alerta import app as application
 EOF
 
 cat >>/etc/alertad.conf << EOF
+BASE_URL='/api'
 SECRET_KEY='$(< /dev/urandom tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+= | head -c 32)'
 AUTH_REQUIRED=$AUTH_REQUIRED
 PLUGINS=['reject', 'blackout']


### PR DESCRIPTION
Update install script used to install and configure Flask-based python / Apache WSGI app to migrate from Python 2 environment to Python 3.

**IMPORTANT - THIS HAS _NOT_ BEEN TESTED IN PRODUCTION, YET!!!**

Notes:
  * this covers apache only, need do this for nginx as well
  * python 3 comes with built in virtualenv called `venv`, but it doesn't have a console script
  * python 3 uses wheels so you need to install `wheel` package
  * python 3 `virtualenv` package doesn't include `activate_this.py` anymore (tho using `venv` anyway)
  * `execfile()` doesn't exist in python 3
  * modern versions of "mod_wsgi" support a new `python-home` setting on `WSGIDaemonProcess` so `activate_this.py` and `execfile()` not needed anyway
 
>If using a Python virtual environment, rather than use this option [`python-path`] to refer to the site-packages directory of the Python virtual environment, you should use the python-home option to specify the root of the Python virtual environment instead.
https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html

References
  * Python Standard Library Docs - `venv` https://docs.python.org/3/library/venv.html
  * https://stackoverflow.com/questions/41573587/what-is-the-difference-between-venv-pyvenv-pyenv-virtualenv-virtualenvwrappe
  * https://www.digitalocean.com/community/tutorials/how-to-serve-django-applications-with-apache-and-mod_wsgi-on-ubuntu-16-04
  * mod_wsgi `WSGIDaemonProcess` https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html

See also https://github.com/pallets/flask/issues/2620 and https://github.com/pallets/flask/issues/1948